### PR TITLE
PFT-swapped simulations for phase 2b

### DIFF
--- a/2a_grass/02_ic_build.R
+++ b/2a_grass/02_ic_build.R
@@ -404,6 +404,7 @@ ic_sample_draws <- function(df, n = 100, ...) {
 }
 
 ic_samples <- initial_condition_estimated |>
+  dplyr::filter(site_id %in% site_info$id) |>
   dplyr::group_by(site_id, variable) |>
   dplyr::group_modify(ic_sample_draws, n = args$ic_ensemble_size) |>
   tidyr::pivot_wider(names_from = variable, values_from = sample) |>

--- a/2a_grass/03_xml_build.R
+++ b/2a_grass/03_xml_build.R
@@ -22,7 +22,7 @@ options <- list(
     )
   ),
   optparse::make_option("--end_date",
-    default = "2023-12-31", # TODO add 2024 when met avail
+    default = "2024-12-31",
     help = "Date to end simulations"
   ),
   optparse::make_option("--ic_dir",
@@ -33,7 +33,7 @@ options <- list(
     )
   ),
   optparse::make_option("--met_dir",
-    default = "data/ERA5_SIPNET",
+    default = "data/ERA5_CA_SIPNET",
     help = paste(
       "Directory containing climate data.",
       "Should contain subdirs named by site id"

--- a/2a_grass/mixed_pfts.Rmd
+++ b/2a_grass/mixed_pfts.Rmd
@@ -1,0 +1,135 @@
+# Modify initial pools for mixed-PFT simulations
+
+Context: To test approaches to simulating mixed PFT management using the
+(single-PFT-at-a-time) Sipnet model, we want to generate simulations of the
+same site using two different PFTS, then experiment with post-processing them
+in different ratios.
+
+One challenge is that initial site conditions are set using remote sensed
+observations that are converted to estimates of pool size using PFT-specific
+assumptions. To convert an IC file to one for a different PFT, we also need
+to begin a switch from setting ICs based on remote sensing to setting them
+based on counterfactual assumptions of what remote sensing _would_ show if
+this site were actually mixed PFTs.
+
+Here I mostly do not address the need for counterfactuals and try to convert
+very simply by starting from sites known to be woody and then converting them
+to grass by:
+
+* Keeping soil C and initial soil water identical
+* Treating sensed LAI as if it were 100% from the PFT to be simulated
+	(this will probably overestimate LAI for all PFTs)
+* Setting sensed woody biomass to zero when simulating a nonwoody PFT
+
+which fields of the IC file to alter?
+	- abvGrdWood and wood_carbon_content = 0 for nonwoody pfts
+	- LAI two options:
+		- leave as-is, accept all PFTs start with too many leaves
+		- scale to area coverage (need to know area coverage at IC setup time)
+		==> I'm leaving as-is
+	- leaf carbon: rescale from LAI using PFT-specific SLA and leafC
+
+To generate site info:
+
+```{r}
+library(tidyverse)
+site_info <- read.csv("site_info.csv", colClasses = c(field_id = "character"))
+tree_sites <- site_info |>
+	filter(site.pft == "temperate.deciduous")
+tree_sites_as_grass <- tree_sites |>
+	mutate(site.pft == "grass",
+	id = paste0(id, "_grass")
+
+write.csv(tree_sites, "site_info_tree.csv", row.names = FALSE)
+write.csv(tree_sites_as_grass, "site_info_tree_as_grass.csv", row.names = FALSE)
+write.csv(
+	bind_rows(tree_sites, tree_sites_as_grass),
+	"site_info_tree_as_both.csv",
+	row.names = FALSE
+)
+```
+
+To generate new IC files taking new draws from all estimated distributions
+
+Note we only regenerate for grass -- tree runs keep using orig file.
+Note also that this adds new entries to the IC data dir (`data/IC_prep/`) for
+all `<id>_grass` sites. You can verify in `data/IC_prep/IC_means.csv` that the
+estimated distributions are the same as for the tree sites -- we change the draws,
+not the distributions of estimated true state.
+
+```{sh}
+./02_ic_build.R --site_info_path=site_info_tree_as_grass.csv \
+	--ic_outdir=IC_nowood_newdraws \
+	--additional_params='varname=wood_carbon_fraction,distn=norm,parama=0.0001,paramb=0.00001'
+mkdir IC_mix_newdraws
+cp IC_files/* IC_mix_newdraws
+cp IC_nowood_newdraws/* IC_mix_newdraws
+```
+
+The big caveat here is that is generates new draws of soilC and initial soil water for each ensemble member.
+
+
+
+
+To generate IC files that maintain the same soil C and water values:
+* set aboveground wood and wood carbon content to 0
+* Scale LAI:
+	- Existing files calculated leaf carbon content as `LAI / SLA * (leafC /100)` = `LAI * (leafC/100)/SLA`
+	- PFT means for SLA: deciduous 15.179 +/- 0.97, grass 10.0 +/- 5.0
+	- PFT means for leafC: deciduous 46.6 +/- 0.088, grass 48.3 +/- 4.0
+	- so first-order correction from woody to grass leaf carbon content is
+		`LAI * ( (48.3/100)/10) / ((46.6/100)/15.179) )`
+		~= `LAI * 0.0483/0.0307`
+		~= `LAI * 1.57`
+	- I say "first-order" correction because each IC file used its own draws of SLA and leafC
+
+```{sh}
+mkdir IC_nowood_samedraws
+cd IC_files
+find . -name '*.nc' -exec \
+	ncap2 -s 'AbvGrndWood=0;wood_carbon_content=0;leaf_carbon_content=leaf_carbon_content*1.57' \
+		{} ../IC_nowood_samedraw/{} \;
+cd ../IC_nowood_samedraw
+find . -type d -exec mv {} {}_grass \;
+find . -name '*.nc' -exec bash -c 'mv {} $(echo {} | sed -E "s/(.*)_([0-9]+.nc)/\1_grass_\2/")' \;
+mkdir IC_mix_samedraws
+cp IC_files/* IC_mix_newdraws
+cp IC_nowood_newdraws/* IC_mix_newdraws
+```
+
+
+```{sh}
+# NB this relies on knowing template.xml had all output paths, and no others,
+# beginning with `output`
+sed 's!>output!>output_mix_samedraws!' template.xml > template_mix_samedraws.xml
+sed 's!>output!>output_mix_newdraws!' template.xml > template_mix_newdraws.xml
+
+./03_xml_build.R \
+	--site_file=site_info_tree_as_grass.csv \
+	--ic_dir=IC_mix_samedraws \
+	--template_file=template_samedraws.xml \
+	--output_file=mix_samedraws.xml
+./03_xml_build.R \
+	--site_file=site_info_tree_as_grass.csv \
+	--ic_dir=IC_mix_newdraws \
+	--template_file=template_newdraws.xml \
+	--output_file=mix_newdraws.xml
+
+./04_run_model.R --settings=mix_samedraws.xml
+./04_run_model.R --settings=mix_newdraws.xml
+```
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This is the notebook I used to generate first-draft outputs of woody and nonwoody PFTs at the same sites, for use in a test of ways to represent mixed-PFT systems.

Also: Switched from separate clim files for every site (which is very inefficient given all sites inside a half-degree ERA5 grid cell get identical files) to a grid-based lookup, and extended the runs to include 2024.