### PR TITLE
Add crop changes via model restart

### DIFF
--- a/examples/3_rowcrop/01_ERA5_nc_to_clim.R
+++ b/examples/3_rowcrop/01_ERA5_nc_to_clim.R
@@ -64,13 +64,12 @@ args <- optparse::OptionParser(option_list = options) |>
 
 future::plan(args$parallel_strategy, workers = args$n_cores)
 
-site_info <- read.csv(args$site_info_file)
-site_info$start_date <- args$start_date
-site_info$end_date <- args$end_date
-
-
-file_info <- site_info |>
-  dplyr::rename(site_id = id) |>
+file_info <- read.csv(args$site_info_file) |>
+  dplyr::distinct(id) |>
+  dplyr::mutate(
+    start_date = args$start_date,
+    end_date = args$end_date
+  ) |>
   dplyr::cross_join(data.frame(ens_id = 1:10))
 
 if (!dir.exists(args$site_sipnet_met_path)) {
@@ -78,16 +77,16 @@ if (!dir.exists(args$site_sipnet_met_path)) {
 }
 furrr::future_pwalk(
   file_info,
-  function(site_id, start_date, end_date, ens_id, ...) {
+  function(id, start_date, end_date, ens_id, ...) {
     PEcAn.SIPNET::met2model.SIPNET(
       in.path = file.path(
         args$site_era5_path,
-        paste("ERA5", site_id, ens_id, sep = "_")
+        paste("ERA5", id, ens_id, sep = "_")
       ),
       start_date = start_date,
       end_date = end_date,
       in.prefix = paste0("ERA5.", ens_id),
-      outfolder = file.path(args$site_sipnet_met_path, site_id)
+      outfolder = file.path(args$site_sipnet_met_path, id)
     )
   }
 )

--- a/examples/3_rowcrop/02a_build_events.R
+++ b/examples/3_rowcrop/02a_build_events.R
@@ -103,6 +103,7 @@ write.csv(pheno, file = pheno_out_path, row.names = FALSE)
 plant <- read_parquet_years(mgmt_subdirs$plant, ids, "site_id") |>
   # TODO fix upstream
   dplyr::rename(
+    crop_code = code,
     leaf_c_kg_m2 = C_LEAF,
     wood_c_kg_m2 = C_STEM,
     fine_root_c_kg_m2 = C_FINEROOT,

--- a/examples/3_rowcrop/02a_build_events.R
+++ b/examples/3_rowcrop/02a_build_events.R
@@ -1,8 +1,9 @@
 #!/usr/bin/env Rscript
 
-# Creates a single PEcAn-formatted `events.JSON` containing all management
+# Creates an ensemble of PEcAn-formatted `events.JSON` containing all management
 # events from all years of all the locations in `site_info.csv`,
-# then divides it into a Sipnet-formatted `events.in` for each site.
+# then divides these into Sipnet-formatted `events.in` for each site.
+# Ensemble size is determined by the number of members in the management files.
 
 ## ---------------------- parse command-line options --------------------------
 options <- list(
@@ -10,12 +11,18 @@ options <- list(
     default = "site_info.csv",
     help = "CSV giving ids, locations, and PFTs for sites of interest"
   ),
-  optparse::make_option("--mgmt_file_dir",
+  optparse::make_option("--raw_parquet_dir",
     default = "data_raw/management",
     help = paste(
       "Directory containing management inputs in Parquet format.",
       "Note: Code currently looks for subpaths that include hard-coded",
       "version numbers for each management type."
+    )
+  ),
+  optparse::make_option("--clean_parquet_dir",
+    default = "data/management_ensembles",
+    help = paste(
+      "Directory containing management inputs cleaned and organized by ensemble member."
     )
   ),
   optparse::make_option("--event_outdir",
@@ -39,11 +46,11 @@ library(tidyverse)
 # TODO these probably deserve to be runtime args,
 # but first better fix other version-specific assumptions below
 mgmt_subdirs <- list(
-  pheno = "phenology/v1.0",
-  plant = "planting/v1.0",
-  harv = "harvest/v1.0",
-  till = "tillage/v1.0",
-  irri = "irrigation/v1.0",
+  pheno = file.path(args$raw_parquet_dir, "phenology/v1.0"),
+  plant = file.path(args$raw_parquet_dir, "planting/v1.0"),
+  harv = file.path(args$raw_parquet_dir, "harvest/v1.0"),
+  till = file.path(args$raw_parquet_dir, "tillage/v1.0"),
+  irri = file.path(args$raw_parquet_dir, "irrigation/max_150/irrigation_all"), # "irrigation/v1.0"),
   fert = NULL, # TODO
   occ = NULL # TODO
 )
@@ -52,110 +59,39 @@ if (!dir.exists(args$event_outdir)) {
   dir.create(args$event_outdir, recursive = TRUE)
 }
 
-ids <- read.csv(
-  args$site_info_path,
-  colClasses = c(field_id = "character")
-)$field_id
-
-# read management files from inside mgmt directory
-# TODO will break if not all mgmt types live at same path
-# (e.g. user wants to pull in their own tillage but use monitored plant/harv)
-read_parquet_years <- function(dir, parcel_ids, id_var = "parcel_id") {
-  file.path(args$mgmt_file_dir, dir) |>
-    list.files("*.parq(uet)?$", full.names = TRUE) |>
-    arrow::open_dataset() |>
-    # as.character is a hack bc planting dataset has id as string some years and int others.
-    # TODO remove when fixed upstream.
-    filter(as.character(.data[[id_var]]) %in% parcel_ids) |>
-    collect()
+cargs <- function(...) {
+  paste0("--", ...names(), "=", list(...))
 }
 
-# phenology doesn't have to be json -- we'll just write one CSV of all sites and years
-pheno <- read_parquet_years(mgmt_subdirs$pheno, ids, "site_id") |>
-  # TODO some seasons wrap past year end (e.g. 2025-09-08 to 2026-03-29) --
-  # current code drops year so leafonday > leafoffday, which write.config skips
-  # as invalid.
-  mutate(
-    leafonday = lubridate::yday(leafonday),
-    leafoffday = lubridate::yday(leafoffday)
+PEcAn.logger::logger.info("Cleaning irrigation files")
+callr::rscript(
+  "../../tools/event_prep/01a-clean-irrigation.R",
+  cmdargs = cargs(
+    irr_path = mgmt_subdirs$irri,
+    outdir = args$clean_parquet_dir
   )
-# If csv exists already, append instead of clobbering
-# TODO keep old version of the dups instead of updating?
-# Not sure which will be less surprising
-pheno_out_path <- file.path(args$event_outdir, "phenology.csv")
-if (file.exists(pheno_out_path)) {
-  existing_pheno <- read.csv(
-    pheno_out_path,
-    colClasses = c(site_id = "character"))
-  site_dups <- intersect(pheno$site_id, existing_pheno$site_id)
-  if (length(site_dups) > 0) {
-    warning(
-      "Overwriting existing phenology records for ",
-      length(site_dups), " sites in ", pheno_out_path
-    )
-  }
-  pheno <- existing_pheno |>
-    filter(!(site_id %in% site_dups)) |>
-    bind_rows(pheno)
-}
-write.csv(pheno, file = pheno_out_path, row.names = FALSE)
-
-plant <- read_parquet_years(mgmt_subdirs$plant, ids, "site_id") |>
-  # TODO fix upstream
-  dplyr::rename(
-    crop_code = code,
-    leaf_c_kg_m2 = C_LEAF,
-    wood_c_kg_m2 = C_STEM,
-    fine_root_c_kg_m2 = C_FINEROOT,
-    coarse_root_c_kg_m2 = C_COARSEROOT,
-  ) |>
-  # Some planting events happen in the year previous to bulk of growth.
-  # This is only a problem at the very start of the run, where the reported
-  # planting date lands before start of simulation and causes a Sipnet error.
-  # Temporary workaround: Adjust dates forward.
-  # TODO: Should also (/instead?) adjust initial pool sizes in these cases.
-  dplyr::mutate(date = pmax(date,  "2016-01-01"))
-
-harv <- read_parquet_years(mgmt_subdirs$harv, ids, "site_id")
-
-till <- read_parquet_years(mgmt_subdirs$till, ids, "site_id") |>
-  mutate(
-    date = OGMn_date,
-    # Placeholder -- better-informed conversion under development.
-    # Note that NaNs get forced to 0. This was an arbitrary choice.
-    tillage_eff_0to1 = pmax(0, pmin(1, ndti_pct_change / 100), na.rm = TRUE)
+)
+PEcAn.logger::logger.info("Cleaning other management files")
+callr::rscript(
+  "../../tools/event_prep/01b-clean-other-events.R",
+  cmdargs = cargs(
+    pheno_dir = mgmt_subdirs$pheno,
+    planting_dir = mgmt_subdirs$plant,
+    harvest_dir = mgmt_subdirs$harv,
+    tillage_dir = mgmt_subdirs$till,
+    adjust_start = "2016-01-01",
+    outdir = args$clean_parquet_dir
   )
-
-irrig <- read_parquet_years(mgmt_subdirs$irri, ids, "parcel_id") |>
-  filter(
-    # Ignore ensemble dimension. TODO support event ensembles across all event types
-    ens_id == "irr_ens_001",
-    # ignore all irrigation events before start of simulation
-    date >= "2016-01-01"
-  ) |>
-  mutate(
-    event_type = "irrigation",
-    site_id = as.character(parcel_id),
-    date = as.character(date)
-  ) |>
-  select(site_id, event_type, date, amount_mm, method)
-
-# TODO add fertilization / NCC here when available
-
-all_events <- dplyr::bind_rows(plant, harv, till, irrig) |>
-  dplyr::arrange(site_id, date, event_type) |>
-  dplyr::nest_by(site_id, .key="events") |>
-  dplyr::mutate(pecan_events_version = "0.1.0")
-
-evt_json_path <- file.path(args$event_outdir, "combined_events.json")
-if (file.exists(evt_json_path)) {
-  # TODO append to existing file like for phenology?
-  # need more care to handle nesting right.
-  warning("Overwriting existing events file ", evt_json_path)
-}
-jsonlite::write_json(all_events, evt_json_path)
-
-# Now divide the json into Sipnet events files
-PEcAn.SIPNET::write.events.SIPNET(evt_json_path, args$event_outdir)
-
+)
+PEcAn.logger::logger.info("converting management files to events")
+callr::rscript(
+  "../../tools/event_prep/02-events-to-json-and-sipnet.R",
+  cmdargs = cargs(
+    site_info_path = args$site_info_path,
+    parquet_dir = args$clean_parquet_dir,
+    event_dir = args$event_outdir,
+    start_date = "2016-01-01",
+    end_date = "2023-12-31"
+  )
+)
 

--- a/examples/3_rowcrop/03_xml_build.R
+++ b/examples/3_rowcrop/03_xml_build.R
@@ -131,6 +131,7 @@ for(i in seq_along(settings$pfts)) {
     settings$pfts[[i]]$posterior.files
   )
 }
+settings$model$binary <- abs_path(settings$model$binary)
 
 settings$ensemble$size <- args$n_ens
 settings$run$inputs$poolinitcond$ensemble <- args$n_ens

--- a/examples/3_rowcrop/03_xml_build.R
+++ b/examples/3_rowcrop/03_xml_build.R
@@ -177,24 +177,22 @@ settings <- settings |>
     path_template = "{path}/{id}/IC_site_{id}_{n}.nc"
   ) |>
   setEnsemblePaths(
-    n_reps = args$n_ens,
+    n_reps = sprintf("%03d", seq_len(args$n_ens)), # yes, n_reps secretly accepts a vector!
     input_type = "events",
     path = args$event_dir,
-    path_template = "{path}/events-{id}.in"
+    path_template = "{path}/ens_{n}/events-{id}.in"
   ) |>
+  # setEnsemblePaths(
+  #   n_reps = sprintf("%03d", seq_len(args$n_ens)),
+  #   input_type = "event_json",
+  #   path = args$event_dir,
+  #   path_template = "{path}/events_ens_{n}.json"
+  # ) |>
   setEnsemblePaths(
-    n_reps = args$n_ens,
-    input_type = "event_json",
+    n_reps = sprintf("%03d", seq_len(args$n_ens)),
+    input_type = "crop_changes",
     path = args$event_dir,
-    path_template = "{path}/ens_events_{n}.json"
-  ) |>
-  # For now, hard-coding one phenology path for all sites, placed inside event dir
-  # TODO make settable?
-  setEnsemblePaths(
-    n_reps = args$n_ens,
-    input_type = "leaf_phenology",
-    path = args$event_dir,
-    path_template = "{path}/phenology.csv"
+    path_template = "{path}/ens_{n}/cycles-{id}.csv"
   ) |>
   papply(add_soil_pft)
 

--- a/examples/3_rowcrop/03_xml_build.R
+++ b/examples/3_rowcrop/03_xml_build.R
@@ -201,11 +201,11 @@ settings <- settings |>
 
 # Update output directories
 # Note that we're assuming local and remote paths are the same.
-settings$outdir <- args$output_dir_name
-settings$modeloutdir <- file.path(args$output_dir_name, "out")
-settings$rundir <- file.path(args$output_dir_name, "run")
-settings$host$outdir <- file.path(args$output_dir_name, "out")
-settings$host$rundir <- file.path(args$output_dir_name, "run")
+settings$outdir <- args$output_dir
+settings$modeloutdir <- file.path(args$output_dir, "out")
+settings$rundir <- file.path(args$output_dir, "run")
+settings$host$outdir <- file.path(args$output_dir, "out")
+settings$host$rundir <- file.path(args$output_dir, "run")
 
 write.settings(
   settings,

--- a/examples/3_rowcrop/03_xml_build.R
+++ b/examples/3_rowcrop/03_xml_build.R
@@ -114,8 +114,8 @@ settings <- read.settings(args$template_file) |>
 
 # Attempt to convert to absolute paths, because the restart code changes
 # working directory and gets confused by relative paths
-# ("But why the getwd()? Won't normalizePath expand it for you?"
-#  Only for existing paths; dirs not yet created need the getwd. Humph.)
+# Q: "But why the getwd()? Won't normalizePath expand it for you?"
+# A: Only for existing paths; dirs not yet created need the getwd. Humph.
 abs_path <- function(path) {
   if (substr(path, 1, 1) != "/") path <- file.path(getwd(), path)
   normalizePath(path, mustWork = FALSE)

--- a/examples/3_rowcrop/03_xml_build.R
+++ b/examples/3_rowcrop/03_xml_build.R
@@ -64,7 +64,7 @@ options <- list(
     default = "settings.xml",
     help = "path to write output XML"
   ),
-  optparse::make_option("--output_dir_name",
+  optparse::make_option("--output_dir",
     default = "output",
     help = paste(
       "Path the settings should declare as output directory.",
@@ -90,6 +90,20 @@ args <- optparse::OptionParser(option_list = options) |>
 
 # papply emits a lot of uninformative debug messages; let's ignore those
 PEcAn.logger::logger.setLevel("INFO")
+
+
+# Attempt to convert to absolute paths, because the restart code changes
+# working directory and gets confused by relative paths
+# ("But why the getwd()? Won't normalizePath expand it for you?"
+#  Only for existing paths; dirs not yet created need the getwd. Humph.)
+abs_path <- function(path) {
+  if (substr(path, 1, 1) != "/") path <- file.path(getwd(), path)
+  normalizePath(path, mustWork = FALSE)
+}
+args$ic_dir <- abs_path(args$ic_dir)
+args$met_dir <- abs_path(args$met_dir)
+args$event_dir <- abs_path(args$event_dir)
+args$output_dir <- abs_path(args$output_dir)
 
 site_info <- read.csv(args$site_file)
 stopifnot(
@@ -176,22 +190,13 @@ settings <- settings |>
   ) |>
   papply(add_soil_pft)
 
-# Update just the first component of the output directory,
-# in all four places it's used.
-# Note: It feels a bit odd to directly replace the word "output"
-# rather than fill a blank or use a @placeholder@, but since existing template
-# already passes @placeholder@'s on to be processed in PEcAn I didn't want
-# to introduce confusion by making some be replaced at a different stage.
-settings$outdir <- sub("^output", args$output_dir_name,
-                       settings$outdir)
-settings$modeloutdir <- sub("^output", args$output_dir_name,
-                            settings$modeloutdir)
-settings$rundir <- sub("^output", args$output_dir_name,
-                       settings$rundir)
-settings$host$outdir <- sub("^output", args$output_dir_name,
-                            settings$host$outdir)
-settings$host$rundir <- sub("^output", args$output_dir_name,
-                            settings$host$rundir)
+# Update output directories
+# Note that we're assuming local and remote paths are the same.
+settings$outdir <- args$output_dir_name
+settings$modeloutdir <- file.path(args$output_dir_name, "out")
+settings$rundir <- file.path(args$output_dir_name, "run")
+settings$host$outdir <- file.path(args$output_dir_name, "out")
+settings$host$rundir <- file.path(args$output_dir_name, "run")
 
 write.settings(
   settings,

--- a/examples/3_rowcrop/03_xml_build.R
+++ b/examples/3_rowcrop/03_xml_build.R
@@ -157,12 +157,6 @@ add_soil_pft <- function(s) {
   s
 }
 
-# The restart functions use this to find the crop type for each planting event
-add_event_source <- function(s) {
-  s$run$inputs$events$source <- file.path(args$event_dir, "combined_events.json")
-  s
-}
-
 settings <- settings |>
   createMultiSiteSettings(site_info) |>
   setEnsemblePaths(
@@ -188,7 +182,12 @@ settings <- settings |>
     path = args$event_dir,
     path_template = "{path}/events-{id}.in"
   ) |>
-  papply(add_event_source) |>
+  setEnsemblePaths(
+    n_reps = args$n_ens,
+    input_type = "event_json",
+    path = args$event_dir,
+    path_template = "{path}/ens_events_{n}.json"
+  ) |>
   # For now, hard-coding one phenology path for all sites, placed inside event dir
   # TODO make settable?
   setEnsemblePaths(

--- a/examples/3_rowcrop/03_xml_build.R
+++ b/examples/3_rowcrop/03_xml_build.R
@@ -134,6 +134,12 @@ add_soil_pft <- function(s) {
   s
 }
 
+# The restart functions use this to find the crop type for each planting event
+add_event_source <- function(s) {
+  s$run$inputs$events$source <- file.path(args$event_dir, "combined_events.json")
+  s
+}
+
 settings <- settings |>
   createMultiSiteSettings(site_info) |>
   setEnsemblePaths(
@@ -159,6 +165,7 @@ settings <- settings |>
     path = args$event_dir,
     path_template = "{path}/events-{id}.in"
   ) |>
+  papply(add_event_source) |>
   # For now, hard-coding one phenology path for all sites, placed inside event dir
   # TODO make settable?
   setEnsemblePaths(

--- a/examples/3_rowcrop/03_xml_build.R
+++ b/examples/3_rowcrop/03_xml_build.R
@@ -92,18 +92,6 @@ args <- optparse::OptionParser(option_list = options) |>
 PEcAn.logger::logger.setLevel("INFO")
 
 
-# Attempt to convert to absolute paths, because the restart code changes
-# working directory and gets confused by relative paths
-# ("But why the getwd()? Won't normalizePath expand it for you?"
-#  Only for existing paths; dirs not yet created need the getwd. Humph.)
-abs_path <- function(path) {
-  if (substr(path, 1, 1) != "/") path <- file.path(getwd(), path)
-  normalizePath(path, mustWork = FALSE)
-}
-args$ic_dir <- abs_path(args$ic_dir)
-args$met_dir <- abs_path(args$met_dir)
-args$event_dir <- abs_path(args$event_dir)
-args$output_dir <- abs_path(args$output_dir)
 
 site_info <- read.csv(args$site_file)
 stopifnot(
@@ -123,6 +111,26 @@ site_info <- site_info |>
 
 settings <- read.settings(args$template_file) |>
   setDates(args$start_date, args$end_date)
+
+# Attempt to convert to absolute paths, because the restart code changes
+# working directory and gets confused by relative paths
+# ("But why the getwd()? Won't normalizePath expand it for you?"
+#  Only for existing paths; dirs not yet created need the getwd. Humph.)
+abs_path <- function(path) {
+  if (substr(path, 1, 1) != "/") path <- file.path(getwd(), path)
+  normalizePath(path, mustWork = FALSE)
+}
+args$ic_dir <- abs_path(args$ic_dir)
+args$met_dir <- abs_path(args$met_dir)
+args$event_dir <- abs_path(args$event_dir)
+args$output_dir <- abs_path(args$output_dir)
+# TODO it's awkward to set PFT paths in the template but then edit them here --
+# consider handling PFT insertion as an arg here?
+for(i in seq_along(settings$pfts)) {
+  settings$pfts[[i]]$posterior.files <- abs_path(
+    settings$pfts[[i]]$posterior.files
+  )
+}
 
 settings$ensemble$size <- args$n_ens
 settings$run$inputs$poolinitcond$ensemble <- args$n_ens

--- a/examples/3_rowcrop/04_set_up_runs.R
+++ b/examples/3_rowcrop/04_set_up_runs.R
@@ -24,7 +24,7 @@ options <- list(
     default = "~/pecan/workflows/sipnet-restart-workflow/utils.R",
     help = paste(
       "File containing R functions implementing crop changes via restart.",
-      "Will be source()'d into the R session."
+      "Will be source()'d into the R session.",
       "This is a temporary option until restart functions are refactored into",
       "package code"
     )

--- a/examples/3_rowcrop/04_set_up_runs.R
+++ b/examples/3_rowcrop/04_set_up_runs.R
@@ -92,5 +92,5 @@ if (PEcAn.utils::status.check("CONFIG") == 0) {
 
 PEcAn.utils::status.start("CONFIG_SEGMENTS")
 source(args$restart_code_location)
-papply(settings, \(s) write_segmented_configs.SIPNET(s, ens_design))
+run_script_paths <- papply(settings, \(s) write_segmented_configs.SIPNET(s, ens_design))
 PEcAn.utils::status.end()

--- a/examples/3_rowcrop/04_set_up_runs.R
+++ b/examples/3_rowcrop/04_set_up_runs.R
@@ -12,13 +12,6 @@ options <- list(
       "working directory of the process that invokes run_model.R,",
       "not relative to the settings file path"
     )
-  ),
-  optparse::make_option(c("-c", "--continue"),
-    default = FALSE,
-    help = paste(
-      "Attempt to pick up in the middle of a previously interrupted workflow?",
-      "Does not work reliably. Use at your own risk"
-    )
   )
 ) |>
   # Show default values in help message

--- a/examples/3_rowcrop/04_set_up_runs.R
+++ b/examples/3_rowcrop/04_set_up_runs.R
@@ -19,15 +19,6 @@ options <- list(
       "Attempt to pick up in the middle of a previously interrupted workflow?",
       "Does not work reliably. Use at your own risk"
     )
-  ),
-  optparse::make_option(c("-r", "--restart_code_location"),
-    default = "~/pecan/workflows/sipnet-restart-workflow/utils.R",
-    help = paste(
-      "File containing R functions implementing crop changes via restart.",
-      "Will be source()'d into the R session.",
-      "This is a temporary option until restart functions are refactored into",
-      "package code"
-    )
   )
 ) |>
   # Show default values in help message
@@ -91,6 +82,8 @@ if (PEcAn.utils::status.check("CONFIG") == 0) {
 }
 
 PEcAn.utils::status.start("CONFIG_SEGMENTS")
-source(args$restart_code_location)
-run_script_paths <- papply(settings, \(s) write_segmented_configs.SIPNET(s, ens_design))
+run_script_paths <- papply(
+  settings,
+  \(s) PEcAn.SIPNET::write_segmented_configs.SIPNET(s, ens_design)
+)
 PEcAn.utils::status.end()

--- a/examples/3_rowcrop/04_set_up_runs.R
+++ b/examples/3_rowcrop/04_set_up_runs.R
@@ -19,6 +19,15 @@ options <- list(
       "Attempt to pick up in the middle of a previously interrupted workflow?",
       "Does not work reliably. Use at your own risk"
     )
+  ),
+  optparse::make_option(c("-r", "--restart_code_location"),
+    default = "~/pecan/workflows/sipnet-restart-workflow/utils.R",
+    help = paste(
+      "File containing R functions implementing crop changes via restart.",
+      "Will be source()'d into the R session."
+      "This is a temporary option until restart functions are refactored into",
+      "package code"
+    )
   )
 ) |>
   # Show default values in help message
@@ -59,19 +68,29 @@ settings <- PEcAn.settings::read.settings(args$settings)
 if (!dir.exists(settings$outdir)) {
   dir.create(settings$outdir, recursive = TRUE)
 }
+PEcAn.logger::logger.setLevel("WARN")
 
-
-# start from scratch if no continue is passed in
-status_file <- file.path(settings$outdir, "STATUS")
-if (args$continue && file.exists(status_file)) {
-  file.remove(status_file)
-}
-
+PEcAn.utils::status.start("DESIGN")
+ens_design <- PEcAn.uncertainty::generate_joint_ensemble_design(
+  settings[[1]],
+  settings$ensemble$size
+)$X
+write.csv(ens_design, file.path(settings$outdir, "input_design.csv"))
+settings$ensemble$id <- rlang::hash(ens_design)
+PEcAn.utils::status.end()
 
 # Write model specific configs
 if (PEcAn.utils::status.check("CONFIG") == 0) {
   PEcAn.utils::status.start("CONFIG")
-  settings <- PEcAn.workflow::runModule.run.write.configs(settings)
+  settings <- PEcAn.workflow::runModule.run.write.configs(
+    settings,
+    input_design = ens_design
+  )
   PEcAn.settings::write.settings(settings, outputfile = "pecan.CONFIGS.xml")
   PEcAn.utils::status.end()
 }
+
+PEcAn.utils::status.start("CONFIG_SEGMENTS")
+source(args$restart_code_location)
+papply(settings, \(s) write_segmented_configs.SIPNET(s, ens_design))
+PEcAn.utils::status.end()

--- a/examples/3_rowcrop/README.md
+++ b/examples/3_rowcrop/README.md
@@ -82,7 +82,7 @@ TODO: show how to pass n_cores from host_args
 [host_args] ./01_ERA5_nc_to_clim.R \
 	--site_era5_path=data_raw/ERA5_CA_nc \
 	--site_sipnet_met_path=data/ERA5_CA_SIPNET \
-	--site_info_file=data_raw/ca_half_degree_grid.csv \
+	--site_info_file=data_raw/ERA5_CA_SIPNET/ca_half_degree_grid.csv \
 	--start_date=2016-01-01 \
 	--end_date=2023-12-31 \
 	--n_cores=7

--- a/examples/3_rowcrop/README.md
+++ b/examples/3_rowcrop/README.md
@@ -148,6 +148,18 @@ vsi |> purrr::pwalk(
   )
 )
 
+# Rename sites inside JSON file, so restart code can match it for PFT changes
+# Doing this by pure substitution, not parsing anything
+evt_json_txt <- readLines("data/val_events/combined_events.json")
+for (i in seq_along(vsi$site_id)) {
+	evt_json_txt <- gsub(
+		pattern = paste0('"site_id":"', vsi$field_id[[i]], '"'),
+		replacement = paste0('"site_id":"', vsi$site_id[[i]], '"'),
+		x = evt_json_txt
+	)
+}
+writeLines(evt_json_txt, "data/val_events/combined_events.json")
+
 # And rename inside the phenology file, too
 read.csv("data/val_events/phenology.csv") |>
   dplyr::rename(field_id = site_id) |>

--- a/examples/3_rowcrop/README.md
+++ b/examples/3_rowcrop/README.md
@@ -165,13 +165,13 @@ read.csv("data/val_events/phenology.csv") |>
 	--site_file=validation_site_info.csv \
 	--event_dir=data/val_events \
 	--output_file=validation_settings.xml \
-	--output_dir_name=val_out
+	--output_dir=val_out
 [host_args] ./03_xml_build.R \
 	--ic_dir=data/IC_files \
 	--end_date=2023-12-31 \
 	--site_file=site_info.csv \
 	--output_file=settings.xml \
-	--output_dir_name=output
+	--output_dir=output
 ```
 
 ### 4. Set up model run directories

--- a/examples/3_rowcrop/template.xml
+++ b/examples/3_rowcrop/template.xml
@@ -43,8 +43,11 @@
    <poolinitcond>
     <method>sampling</method>
    </poolinitcond>
-   <events>
+   <event_json>
     <method>sampling</method>
+   </event_json>
+   <events>
+    <parent>event_json</parent>
    </events>
    <leaf_phenology>
     <method>sampling</method>
@@ -94,6 +97,10 @@
      <ensemble><!-- inserted at config time --></ensemble>
      <path><!-- inserted at config time --></path>
    </poolinitcond>
+   <event_json>
+     <ensemble><!-- inserted at config time --></ensemble>
+     <path><!-- inserted at config time --></path>
+   </event_json>
    <events>
      <ensemble><!-- inserted at config time --></ensemble>
      <path><!-- inserted at config time --></path>

--- a/examples/3_rowcrop/template.xml
+++ b/examples/3_rowcrop/template.xml
@@ -43,15 +43,12 @@
    <poolinitcond>
     <method>sampling</method>
    </poolinitcond>
-   <event_json>
-    <method>sampling</method>
-   </event_json>
+   <crop_changes>
+    <parent>events</parent>
+   </crop_changes>
    <events>
-    <parent>event_json</parent>
-   </events>
-   <leaf_phenology>
     <method>sampling</method>
-   </leaf_phenology>
+   </events>
    <!-- TODO soil physics here when ready -->
   </samplingspace>
   <start.year><!-- inserted at config time --></start.year>
@@ -105,9 +102,6 @@
      <ensemble><!-- inserted at config time --></ensemble>
      <path><!-- inserted at config time --></path>
    </events>
-   <leaf_phenology>
-    <path><!-- inserted at config time --></path>
-   </leaf_phenology>
   </inputs>
   <start.date><!-- inserted at config time --></start.date>
   <end.date><!-- inserted at config time --></end.date>

--- a/examples/3_rowcrop/template.xml
+++ b/examples/3_rowcrop/template.xml
@@ -57,14 +57,15 @@
  <model>
   <id>99000000003</id>
   <type>SIPNET</type>
-  <revision>2.0.0</revision>
-  <delete.raw>TRUE</delete.raw>
+  <revision>2.1.0</revision>
+  <delete.raw>FALSE</delete.raw>
   <binary>./sipnet</binary>
   <options>
     <GDD>0</GDD>
     <NITROGEN_CYCLE>0</NITROGEN_CYCLE>
     <ANAEROBIC>0</ANAEROBIC>
     <LITTER_POOL>1</LITTER_POOL>
+    <RESTART_OUT>restart.out</RESTART_OUT>
   </options>
  </model>
  <host>

--- a/examples/3_rowcrop/template.xml
+++ b/examples/3_rowcrop/template.xml
@@ -12,21 +12,18 @@
   <pft>
    <name>annual_crop</name>
    <posterior.files>data_raw/pfts/annual_crop/post.distns.Rdata</posterior.files>
-   <outdir>data_raw/pfts/annual_crop/</outdir>
   </pft>
   <pft>
    <name>temperate.deciduous</name>
    <posterior.files>data_raw/pfts/temperate.deciduous/post.distns.Rdata</posterior.files>
-   <outdir>data_raw/pfts/temperate.deciduous/</outdir>
   </pft>
   <pft>
    <name>grass</name>
    <posterior.files>data_raw/pfts/grass/post.distns.Rdata</posterior.files>
-   <outdir>data_raw/pfts/grass</outdir>
   </pft>
   <pft>
    <name>soil</name>
-   <outdir>data_raw/pfts/soil/</outdir>
+   <posterior.files>data_raw/pfts/soil/trait.mcmc.RData</posterior.files>
   </pft>
  </pfts>
  <ensemble>

--- a/examples/3_rowcrop/template.xml
+++ b/examples/3_rowcrop/template.xml
@@ -94,10 +94,10 @@
      <ensemble><!-- inserted at config time --></ensemble>
      <path><!-- inserted at config time --></path>
    </poolinitcond>
-   <event_json>
+   <crop_changes>
      <ensemble><!-- inserted at config time --></ensemble>
      <path><!-- inserted at config time --></path>
-   </event_json>
+   </crop_changes>
    <events>
      <ensemble><!-- inserted at config time --></ensemble>
      <path><!-- inserted at config time --></path>

--- a/tools/event_prep/01a-clean-irrigation.R
+++ b/tools/event_prep/01a-clean-irrigation.R
@@ -1,0 +1,62 @@
+#!/usr/bin/env Rscript
+
+# Adapted from a more generic script maintained as part of PEcAn.
+# Its path in the PEcAn repository is workflows/preprocess-event-parquet/01a-clean-irrigation.R.
+# Modifications added here: argument parsing.
+
+## ---------------------- parse command-line options --------------------------
+options <- list(
+  optparse::make_option("--irr_path",
+    default = "data_raw/management/irrigation/v1.0",
+    help = "Directory containing Parquet files of irrigation events"
+  ),
+  optparse::make_option("--outdir",
+    default = "data/management/irrigation",
+    help = paste(
+      "Directory to write cleaned irrigation events.",
+      "Format will be Parquet organized by ensemble member,",
+      "with subdirectories named in 'hive partion' style."
+    )
+  )
+) |>
+  # Show default values in help message
+  purrr::modify(\(x) {
+    x@help <- paste(x@help, "[default: %default]")
+    x
+  })
+
+args <- optparse::OptionParser(option_list = options) |>
+  optparse::parse_args()
+
+## -------------------------- end option parsing ------------------------------
+
+dir.create(args$outdir, showWarnings = FALSE, recursive = TRUE)
+
+dbdir <- file.path(Sys.getenv("TMPDIR", "/tmp"), "temp.duckdb")
+conn <- DBI::dbConnect(duckdb::duckdb(dbdir = dbdir))
+
+# Cast ensemble ID to an enum to accelerate and reduce the memory pressure of
+# the sort.
+DBI::dbExecute(conn, glue::glue("
+  CREATE OR REPLACE TYPE ens_id_enum AS ENUM (
+    SELECT DISTINCT ens_id FROM read_parquet('{args$irr_path}')
+  )
+  "
+))
+
+# Now, sort and write the (partitioned) parquet output
+DBI::dbExecute(conn, glue::glue("
+  COPY (
+    SELECT
+      CAST (parcel_id AS INTEGER) AS site_id,
+      CAST (ens_id AS ens_id_enum) AS event_member_id,
+      date,
+      CAST (amount_mm AS DECIMAL(6, 2)) AS amount_mm,
+      method
+    FROM read_parquet('{args$irr_path}')
+    ORDER BY event_member_id, site_id, date
+  ) TO
+  '{args$outdir}/irrigation.parquet' 
+  (FORMAT PARQUET, COMPRESSION ZSTD, OVERWRITE, PARTITION_BY (event_member_id))
+  "
+))

--- a/tools/event_prep/01a-clean-irrigation.R
+++ b/tools/event_prep/01a-clean-irrigation.R
@@ -32,8 +32,12 @@ args <- optparse::OptionParser(option_list = options) |>
 
 dir.create(args$outdir, showWarnings = FALSE, recursive = TRUE)
 
-dbdir <- file.path(Sys.getenv("TMPDIR", "/tmp"), "temp.duckdb")
+dbdir <- tempfile("duckdb", fileext = ".duckdb")
 conn <- DBI::dbConnect(duckdb::duckdb(dbdir = dbdir))
+on.exit({
+  DBI::dbDisconnect(conn, shutdown = TRUE)
+  unlink(dbdir, recursive = TRUE)
+}, add = TRUE)
 
 # Cast ensemble ID to an enum to accelerate and reduce the memory pressure of
 # the sort.

--- a/tools/event_prep/01b-clean-other-events.R
+++ b/tools/event_prep/01b-clean-other-events.R
@@ -16,7 +16,7 @@ options <- list(
   ),
   optparse::make_option("--harvest_dir",
     default = "data_raw/management/harvest/v1.0",
-    help = "Directory containing Parquet files of hrvest events"
+    help = "Directory containing Parquet files of harvest events"
   ),
   optparse::make_option("--tillage_dir",
     default = "data_raw/management/tillage/v1.0",

--- a/tools/event_prep/01b-clean-other-events.R
+++ b/tools/event_prep/01b-clean-other-events.R
@@ -54,7 +54,7 @@ args <- optparse::OptionParser(option_list = options) |>
 ## -------------------------- end option parsing ------------------------------
 
 
-harvest_files <- list.files(args$harvest_dir, "\\.parquet", full.names = TRUE, recursive = TRUE)
+harvest_files <- list.files(args$harvest_dir, "\\.parquet$", full.names = TRUE, recursive = TRUE)
 planting_files <- list.files(args$planting_dir, "\\.parquet$", full.names = TRUE, recursive = TRUE)
 phenology_files <- list.files(args$pheno_dir, "\\.parquet$", full.names = TRUE, recursive = TRUE)
 tillage_files <- list.files(args$tillage_dir, "\\.parquet$", full.names = TRUE, recursive = TRUE)

--- a/tools/event_prep/01b-clean-other-events.R
+++ b/tools/event_prep/01b-clean-other-events.R
@@ -1,0 +1,148 @@
+#!/usr/bin/env Rscript
+
+# Adapted from a more generic script maintained as part of PEcAn.
+# Its path in the PEcAn repository is workflows/preprocess-event-parquet/01b-clean-other-events.R.
+# Modifications added here: argument parsing, filtering/rescheduling of events outside the simulation date range.
+
+## ---------------------- parse command-line options --------------------------
+options <- list(
+  optparse::make_option("--pheno_dir",
+    default = "data_raw/management/phenology/v1.0",
+    help = "Directory containing Parquet files of phenology (leafon/leafoff) events"
+  ),
+  optparse::make_option("--planting_dir",
+    default = "data_raw/management/planting/v1.0",
+    help = "Directory containing Parquet files of planting events"
+  ),
+  optparse::make_option("--harvest_dir",
+    default = "data_raw/management/harvest/v1.0",
+    help = "Directory containing Parquet files of hrvest events"
+  ),
+  optparse::make_option("--tillage_dir",
+    default = "data_raw/management/tillage/v1.0",
+    help = "Directory containing Parquet files of tillage events"
+  ),
+  # Fertilization and organic amendment files can be added here when ready
+  # optparse::make_option("--fert_dir",...),
+  # optparse::make_option("--ncc_dir",...),
+  optparse::make_option("--outdir",
+    default = "data/management/",
+    help = paste(
+      "Directory to write cleaned events.",
+      "Format will be a single Parquet file per event type."
+    )
+  ),
+  optparse::make_option("--adjust_start",
+    default = "2016-01-01",
+    help = paste(
+      "Used by planting and leafon only:",
+      "Events before this date (e.g. winter planting of a spring crop)",
+      "are adjusted forward to happen on the first simulation day.",
+      "this ensures they are seen by Sipnet rather than filtered out"
+    )
+  )
+) |>
+  # Show default values in help message
+  purrr::modify(\(x) {
+    x@help <- paste(x@help, "[default: %default]")
+    x
+  })
+
+args <- optparse::OptionParser(option_list = options) |>
+  optparse::parse_args()
+
+## -------------------------- end option parsing ------------------------------
+
+
+harvest_files <- list.files(args$harvest_dir, "\\.parquet", full.names = TRUE, recursive = TRUE)
+planting_files <- list.files(args$planting_dir, "\\.parquet$", full.names = TRUE, recursive = TRUE)
+phenology_files <- list.files(args$pheno_dir, "\\.parquet$", full.names = TRUE, recursive = TRUE)
+tillage_files <- list.files(args$tillage_dir, "\\.parquet$", full.names = TRUE, recursive = TRUE)
+dir.create(args$outdir, showWarnings = FALSE, recursive = TRUE)
+
+message("Writing harvest output")
+harvest <- arrow::open_dataset(harvest_files, format = "parquet") |>
+  dplyr::mutate(
+    site_id = as.integer(site_id),
+    date = as.Date(date)
+  ) |>
+  dplyr::arrange(.data$site_id) |>
+  arrow::write_parquet(
+    file.path(args$outdir, "harvest.parquet"),
+    compression = "ZSTD"
+  )
+
+message("Writing planting output")
+planting <- arrow::open_dataset(planting_files, format = "parquet") |>
+  dplyr::mutate(
+    site_id = as.integer(site_id),
+    date = pmax(as.Date(date), as.Date(args$adjust_start)) # push earlier plantings forward to avoid beginning-of-run boundary error
+  ) |>
+  dplyr::rename(
+    crop_code = "code",
+    leaf_c_kg_m2 = "C_LEAF",
+    wood_c_kg_m2 = "C_STEM",
+    fine_root_c_kg_m2 = "C_FINEROOT",
+    coarse_root_c_kg_m2 = "C_COARSEROOT",
+    leaf_n_kg_m2 = "N_LEAF",
+    wood_n_kg_m2 = "N_STEM",
+    fine_root_n_kg_m2 = "N_FINEROOT",
+    coarse_root_n_kg_m2 = "N_COARSEROOT"
+  ) |>
+  arrow::write_parquet(
+    file.path(args$outdir, "planting.parquet"),
+    compression = "ZSTD"
+  )
+
+# Equation is from PEcAn.data.land::ndti_to_sipnet_tillage,
+# reimplemented here in simpler form so that Arrow's expression parser can
+#  execute it directly as C++ without needing to pull the dataset back into R
+pct_to_tillage <- function (delta_ndti, no_till_threshold = 0.3, slope = 2.5) {
+  pmin(pmax(((delta_ndti/100) - no_till_threshold) * slope,
+            0),
+       1)
+}
+
+message("Writing tillage output")
+tillage <- arrow::open_dataset(tillage_files, format = "parquet") |>
+  dplyr::filter(
+    is.finite(.data$ndti_pct_change),
+    .data$ndti_pct_change >= 0
+  ) |>
+  dplyr::mutate(
+    site_id = as.integer(site_id),
+    tillage_eff_0to1 = pct_to_tillage(ndti_pct_change),
+    date = as.Date(.data$OGMn_date)
+  ) |>
+  dplyr::select(
+    "site_id",
+    "date",
+    "tillage_eff_0to1"
+  ) |>
+  arrow::write_parquet(
+    file.path(args$outdir, "tillage.parquet"),
+    compression = "ZSTD"
+  )
+
+message("Writing phenology output")
+phenology <- arrow::open_dataset(phenology_files, format = "parquet")
+leafon <- phenology |>
+  dplyr::select("site_id", date = "leafonday") |>
+  dplyr::mutate(
+    site_id = as.integer(.data$site_id),
+    date = pmax(as.Date(date), as.Date(args$adjust_start)) # push earlier leafons forward to avoid beginning-of-run boundary error
+  )|>
+  arrow::write_parquet(
+    file.path(args$outdir, "leafon.parquet"),
+    compression = "ZSTD"
+  )
+leafoff <- phenology |>
+  dplyr::select("site_id", date = "leafoffday") |>
+  dplyr::mutate(
+    site_id = as.integer(.data$site_id),
+    date = as.Date(.data$date)
+  ) |>
+  arrow::write_parquet(
+    file.path(args$outdir, "leafoff.parquet"),
+    compression = "ZSTD"
+  )

--- a/tools/event_prep/02-events-to-json-and-sipnet.R
+++ b/tools/event_prep/02-events-to-json-and-sipnet.R
@@ -1,0 +1,95 @@
+#!/usr/bin/env Rscript
+
+
+
+# Adapted from a more generic script maintained as part of PEcAn.
+# Its path in the PEcAn repository is workflows/preprocess-event-parquet/02_events-to-json.R.
+# Modifications added here: argument parsing, site specification via CSV, writing Sipnet event files in same step as validation
+
+## ---------------------- parse command-line options --------------------------
+options <- list(
+  optparse::make_option("--site_info_path",
+    default = "site_info.csv",
+    help = "CSV giving ids, locations, and PFTs for sites of interest"
+  ),
+  optparse::make_option("--parquet_dir",
+    default = "data/management/",
+    help = paste(
+      "Directory containing Parquet files of each event type,",
+      "either as single files or Hive-partitioned subdirectories",
+      "named `<event_type>.parquet`"
+    )
+  ),
+  optparse::make_option("--event_dir",
+    default = "data/events/",
+    help = "Directory to write combined events as one JSON file per ensemble member"
+  ),
+  optparse::make_option("--start_date",
+    default = "2016-01-01",
+    help = "Remove events before this date"
+  ),
+  optparse::make_option("--end_date",
+    default = "2023-12-31",
+    help = "Remove events after this date"
+  )
+) |>
+  # Show default values in help message
+  purrr::modify(\(x) {
+    x@help <- paste(x@help, "[default: %default]")
+    x
+  })
+
+args <- optparse::OptionParser(option_list = options) |>
+  optparse::parse_args()
+
+## -------------------------- end option parsing ------------------------------
+
+
+dir.create(args$event_dir, showWarnings = FALSE, recursive = TRUE)
+site_ids <- read.csv(args$site_info_path)$id
+
+ens_ids <- PEcAn.data.land::get_event_ensemble_ids(parquet_dir = args$parquet_dir)
+
+events_ensemble_manifest <- dplyr::as_tibble(ens_ids) |>
+  dplyr::mutate(
+    ensemble_id = sprintf("ens_%03d", dplyr::row_number()),
+    json_path = file.path(
+      .env$args$event_dir,
+      sprintf("events_%s.json", .data$ensemble_id)
+    )
+  ) |>
+  dplyr::relocate("ensemble_id", "json_path")
+
+events_files <- PEcAn.data.land::event_parquet_to_json(
+  parquet_dir = args$parquet_dir,
+  events_ensemble_manifest = events_ensemble_manifest,
+  site_ids = site_ids,
+  start_date = args$start_date,
+  end_date = args$end_date
+)
+
+
+message("Validating event files and converting to Sipnet .in format")
+pb <- utils::txtProgressBar(0, nrow(events_files))
+for (i in seq_len(nrow(events_files))) {
+  path <- events_files[["json_path"]][[i]]
+  # TODO I'd prefer to organize event files by site then rep,
+  # but rep then site is easier with current write.events.SIPNET behavior
+  # of writing to outdir/events-<siteid>.in.
+  # For today let's go with what's easy
+  ensdir <- file.path(args$event_dir, events_files[["ensemble_id"]][[i]])
+  PEcAn.SIPNET::write.events.SIPNET(path, ensdir)
+  PEcAn.data.land::events_to_crop_cycle_starts(path) |>
+    dplyr::group_by(site_id) |>
+    dplyr::group_walk(~write.csv(
+      .x,
+      file = file.path(
+        ensdir,
+        paste0("cycles-", .y$site_id, ".csv")
+      ),
+      row.names = FALSE
+    ))
+  utils::setTxtProgressBar(pb, i)
+}
+close(pb)
+


### PR DESCRIPTION
Adds @ashiklom's crop-changing pipeline from https://github.com/PecanProject/pecan/pull/3919 into the MAGiC ensemble pipeline.

Points for discussion:
* Currently sourcing functions in from the pecan repo because that was the fastest route to seeing it run; it's possible we'll want to move those into a package (likely PEcAn.SIPNET?) before merging this.
* Expands (almost) all relative paths to absolute at the settings-construction stage, so that the restart workflow can avoid editing paths as it changes directory. 
    - I don't like this solution -- I was so happy a year or two ago to be able to switch _to_ relative paths in the settings file! -- but don't see a good alternative. Do you?
    - Whether or not absolute paths are the right solution, is `xml_build.R` the correct/easiest/cleanest place for the expansion to happen if we're doing it?